### PR TITLE
fix: prevent bullets from passing through obstacles

### DIFF
--- a/src/main/java/dev/Entity.java
+++ b/src/main/java/dev/Entity.java
@@ -39,12 +39,13 @@ public abstract class Entity {
     }
 
     public boolean collides(Entity other) {
-        boolean c1 = this.posX > other.getPosX();
-        boolean c2 = this.posX < other.getPosX() + other.getWidth();
-        boolean c3 = this.posY > other.getPosY();
-        boolean c4 = this.posY < other.getPosY() + other.getHeight();
-        boolean collision = c1 && c2 && c3 && c4;
-        if (collision){
+        // Full AABB overlap check (fixes bullets passing through obstacles)
+        boolean overlapX = this.posX < other.getPosX() + other.getWidth()
+                        && this.posX + this.width > other.getPosX();
+        boolean overlapY = this.posY < other.getPosY() + other.getHeight()
+                        && this.posY + this.height > other.getPosY();
+        boolean collision = overlapX && overlapY;
+        if (collision) {
             System.out.println("collision");
         }
         return collision;

--- a/src/main/java/dev/Game.java
+++ b/src/main/java/dev/Game.java
@@ -137,12 +137,15 @@ public class Game implements Runnable {
                 server.getUserBullets().remove(j--); //check if bullet is out of frame
                 continue;
             }
+            boolean hitObstacle = false;
             for (int i = 0; i < obstacles.size(); i++) {
                 if (obstacles.get(i).collides(server.getUserBullets().get(j))) {
                     server.getUserBullets().remove(j--);
-                    continue;
+                    hitObstacle = true;
+                    break;
                 }
             }
+            if (hitObstacle) continue;
 
         }
     }


### PR DESCRIPTION
- Replace point-in-box collision check with proper AABB overlap in Entity.collides()
- Fix loop logic in Game.checkObjectCollision() to break early and skip duplicate removal after bullet hits an obstacle